### PR TITLE
If preferred value not present, return non-preferred values

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,7 @@ Style/OpenStructUse:
   Exclude:
     - 'lib/psu_identity/search_service/atomic_link.rb'
     - 'spec/lib/psu_identity/search_service/atomic_link_spec.rb'
+
+Rspec/NestedGroups:
+  Exclude:
+    - 'spec/lib/psu_identity/search_service/person_spec.rb'

--- a/lib/psu_identity/search_service/person.rb
+++ b/lib/psu_identity/search_service/person.rb
@@ -39,19 +39,19 @@ module PsuIdentity::SearchService
     end
 
     def preferred_given_name
-      data.fetch('preferredGivenName', given_name)
+      presence(data['preferredGivenName']) || given_name
     end
 
     def preferred_middle_name
-      data.fetch('preferredMiddleName', middle_name)
+      presence(data['preferredMiddleName']) || middle_name
     end
 
     def preferred_family_name
-      data.fetch('preferredFamilyName', family_name)
+      presence(data['preferredFamilyName']) || family_name
     end
 
     def preferred_honorific_suffix
-      data.fetch('preferredHonorificSuffix', honorific_suffix)
+      presence(data['preferredHonorificSuffix']) || honorific_suffix
     end
 
     def active?
@@ -81,5 +81,15 @@ module PsuIdentity::SearchService
     def link
       AtomicLink.new(data['link'])
     end
+
+    private
+
+      def presence(string)
+        return nil if string == nil
+
+        return nil if string == ''
+
+        return string
+      end
   end
 end

--- a/lib/psu_identity/search_service/person.rb
+++ b/lib/psu_identity/search_service/person.rb
@@ -89,7 +89,7 @@ module PsuIdentity::SearchService
 
         return nil if string == ''
 
-        return string
+        string
       end
   end
 end

--- a/spec/lib/psu_identity/search_service/person_spec.rb
+++ b/spec/lib/psu_identity/search_service/person_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PsuIdentity::SearchService::Person do
 
     context 'when preferredGivenName is not present' do
       context 'when givenName is not present' do
-        subject { described_class.new() }
+        subject { described_class.new }
 
         its(:preferred_given_name) { is_expected.to eq(nil) }
       end
@@ -90,7 +90,7 @@ RSpec.describe PsuIdentity::SearchService::Person do
 
     context 'when preferredMiddleName is not present' do
       context 'when middleName is not present' do
-        subject { described_class.new() }
+        subject { described_class.new }
 
         its(:preferred_middle_name) { is_expected.to eq(nil) }
       end
@@ -126,7 +126,7 @@ RSpec.describe PsuIdentity::SearchService::Person do
 
     context 'when preferredFamilyName is not present' do
       context 'when familyName is not present' do
-        subject { described_class.new() }
+        subject { described_class.new }
 
         its(:preferred_family_name) { is_expected.to eq(nil) }
       end
@@ -162,7 +162,7 @@ RSpec.describe PsuIdentity::SearchService::Person do
 
     context 'when preferredHonorificSuffix is not present' do
       context 'when honorificSuffix is not present' do
-        subject { described_class.new() }
+        subject { described_class.new }
 
         its(:preferred_honorific_suffix) { is_expected.to eq(nil) }
       end

--- a/spec/lib/psu_identity/search_service/person_spec.rb
+++ b/spec/lib/psu_identity/search_service/person_spec.rb
@@ -46,27 +46,147 @@ RSpec.describe PsuIdentity::SearchService::Person do
   end
 
   describe '#preferred_given_name' do
-    subject { described_class.new('preferredGivenName' => 'abc123') }
+    context 'when preferredGivenName is present' do
+      subject { described_class.new('preferredGivenName' => 'abc123', 'givenName' => 'def321') }
 
-    its(:preferred_given_name) { is_expected.to eq('abc123') }
+      its(:preferred_given_name) { is_expected.to eq('abc123') }
+    end
+
+    context 'when preferredGivenName is not present' do
+      context 'when givenName is not present' do
+        subject { described_class.new() }
+
+        its(:preferred_given_name) { is_expected.to eq(nil) }
+      end
+
+      context 'when givenName is present' do
+        subject { described_class.new('givenName' => 'abc123') }
+
+        its(:preferred_given_name) { is_expected.to eq('abc123') }
+      end
+    end
+
+    context 'when preferredGivenName is an empty string' do
+      context 'when givenName is not present' do
+        subject { described_class.new('preferredGivenName' => '') }
+
+        its(:preferred_given_name) { is_expected.to eq(nil) }
+      end
+
+      context 'when givenName is present' do
+        subject { described_class.new('preferredGivenName' => '', 'givenName' => 'abc123') }
+
+        its(:preferred_given_name) { is_expected.to eq('abc123') }
+      end
+    end
   end
 
   describe '#preferred_middle_name' do
-    subject { described_class.new('preferredMiddleName' => 'abc123') }
+    context 'when preferredMiddleName is present' do
+      subject { described_class.new('preferredMiddleName' => 'abc123', 'middleName' => 'def321') }
 
-    its(:preferred_middle_name) { is_expected.to eq('abc123') }
+      its(:preferred_middle_name) { is_expected.to eq('abc123') }
+    end
+
+    context 'when preferredMiddleName is not present' do
+      context 'when middleName is not present' do
+        subject { described_class.new() }
+
+        its(:preferred_middle_name) { is_expected.to eq(nil) }
+      end
+
+      context 'when middleName is present' do
+        subject { described_class.new('middleName' => 'abc123') }
+
+        its(:preferred_middle_name) { is_expected.to eq('abc123') }
+      end
+    end
+
+    context 'when preferredMiddleName is an empty string' do
+      context 'when middleName is not present' do
+        subject { described_class.new('preferredMiddleName' => '') }
+
+        its(:preferred_middle_name) { is_expected.to eq(nil) }
+      end
+
+      context 'when middleName is present' do
+        subject { described_class.new('preferredMiddleName' => '', 'middleName' => 'abc123') }
+
+        its(:preferred_middle_name) { is_expected.to eq('abc123') }
+      end
+    end
   end
 
   describe '#preferred_family_name' do
-    subject { described_class.new('preferredFamilyName' => 'abc123') }
+    context 'when preferredFamilyName is present' do
+      subject { described_class.new('preferredFamilyName' => 'abc123', 'familyName' => 'def321') }
 
-    its(:preferred_family_name) { is_expected.to eq('abc123') }
+      its(:preferred_family_name) { is_expected.to eq('abc123') }
+    end
+
+    context 'when preferredFamilyName is not present' do
+      context 'when familyName is not present' do
+        subject { described_class.new() }
+
+        its(:preferred_family_name) { is_expected.to eq(nil) }
+      end
+
+      context 'when familyName is present' do
+        subject { described_class.new('familyName' => 'abc123') }
+
+        its(:preferred_family_name) { is_expected.to eq('abc123') }
+      end
+    end
+
+    context 'when preferredFamilyName is an empty string' do
+      context 'when familyName is not present' do
+        subject { described_class.new('preferredFamilyName' => '') }
+
+        its(:preferred_family_name) { is_expected.to eq(nil) }
+      end
+
+      context 'when familyName is present' do
+        subject { described_class.new('preferredFamilyName' => '', 'familyName' => 'abc123') }
+
+        its(:preferred_family_name) { is_expected.to eq('abc123') }
+      end
+    end
   end
 
   describe '#preferred_honorific_suffix' do
-    subject { described_class.new('preferredHonorificSuffix' => 'abc123') }
+    context 'when preferredHonorificSuffix is present' do
+      subject { described_class.new('preferredHonorificSuffix' => 'abc123', 'honorificSuffix' => 'def321') }
 
-    its(:preferred_honorific_suffix) { is_expected.to eq('abc123') }
+      its(:preferred_honorific_suffix) { is_expected.to eq('abc123') }
+    end
+
+    context 'when preferredHonorificSuffix is not present' do
+      context 'when honorificSuffix is not present' do
+        subject { described_class.new() }
+
+        its(:preferred_honorific_suffix) { is_expected.to eq(nil) }
+      end
+
+      context 'when honorificSuffix is present' do
+        subject { described_class.new('honorificSuffix' => 'abc123') }
+
+        its(:preferred_honorific_suffix) { is_expected.to eq('abc123') }
+      end
+    end
+
+    context 'when preferredHonorificSuffix is an empty string' do
+      context 'when honorificSuffix is not present' do
+        subject { described_class.new('preferredHonorificSuffix' => '') }
+
+        its(:preferred_honorific_suffix) { is_expected.to eq(nil) }
+      end
+
+      context 'when honorificSuffix is present' do
+        subject { described_class.new('preferredHonorificSuffix' => '', 'honorificSuffix' => 'abc123') }
+
+        its(:preferred_honorific_suffix) { is_expected.to eq('abc123') }
+      end
+    end
   end
 
   describe '#university_email' do


### PR DESCRIPTION
We have an issue in scholarsphere where if a preferred name is not present in identity services it will return nil and break things.  I _thought_ this was fixed in a previous version of this gem, but it turns out I never fully fixed the issue.  The problem is described here: #14.  I claim it was fixed, but I actually implemented the solution wrong by using `.fetch`.  `.fetch` doesn't work the way I thought it did.  `.fetch` only returns the value in the second argument if the first value is not a hash key in the hash it's being called on.  What we need is something to return the non-preferred name values if the preferred values are nil, '', or not in the hash at all.  The changes I made in this PR should do that.

Let me know if this doesn't sound right @Smullz622 @whereismyjetpack 