### PR TITLE
Auth scheme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    psu_identity (0.6.0)
+    psu_identity (0.6.1)
       faraday (~> 1.0)
       json
       oauth2

--- a/lib/psu_identity/directory_service/client.rb
+++ b/lib/psu_identity/directory_service/client.rb
@@ -51,10 +51,15 @@ module PsuIdentity::DirectoryService
       def token
         oauth_client = OAuth2::Client.new(client_id,
                                           client_secret, site: oauth_endpoint,
+                                                         auth_scheme:,
                                                          authorize_url: '/oauth/api/authz',
                                                          token_url: '/oauth/api/token')
         oauth_token = oauth_client.client_credentials.get_token
         oauth_token.token
+      end
+
+      def auth_scheme
+        @auth_scheme ||= ENV.fetch('PSU_ID_AUTH_SCHEME', 'request_body').to_sym
       end
 
       def client_id

--- a/lib/psu_identity/version.rb
+++ b/lib/psu_identity/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PsuIdentity
-  VERSION = '0.6.0'
+  VERSION = '0.6.1'
 end


### PR DESCRIPTION
allows clients to pass an auth scheme. 

previously we were using the default auth_scheme that oauth2 was using. 1.x versions of oauth2 use `:request_body`, and 2.x use `:basic_auth` 

this hotfix allows us to override the default since we have some projects that resolve to oauth2 2.x and some that resolve to oauth2 1.x 

